### PR TITLE
[40기 서혜선] ADD: 메인페이지 레이아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "qs": "^6.11.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.6.0",
@@ -4966,6 +4965,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/add": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/add/-/add-2.0.6.tgz",
+      "integrity": "sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q=="
     },
     "node_modules/address": {
       "version": "1.2.2",
@@ -21169,6 +21173,11 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+    },
+    "add": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/add/-/add-2.0.6.tgz",
+      "integrity": "sha512-j5QzrmsokwWWp6kUcJQySpbG+xfOBqqKnup3OIk1pz+kB/80SLorZ9V8zHFLO92Lcd+hbvq8bT+zOGoPkmBV0Q=="
     },
     "address": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "qs": "^6.11.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.0",

--- a/public/data/productData.json
+++ b/public/data/productData.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": 1,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1512374382149-233c42b6a83b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=80",
+    "brandName": "Nike",
+    "enName": "Dunk Low Wolf Grey Rosewood",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 140000
+  },
+  {
+    "id": 2,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1597045566677-8cf032ed6634?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "Jordan",
+    "enName": "Jordan 1 x Travis Scott Retro Low OG SP Black Phantom",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 990000
+  },
+  {
+    "id": 3,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1511405946472-a37e3b5ccd47?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "IAB",
+    "enName": "IAB Studio Pigment Sweatshirt & Mini Bag Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 139000
+  },
+  {
+    "id": 4,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1551028719-00167b16eac5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=8",
+    "brandName": "The North Face",
+    "enName": "The North Face 1996 Eco Nuptse Jacket Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 275000
+  },
+  {
+    "id": 5,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1512374382149-233c42b6a83b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=80",
+    "brandName": "Nike",
+    "enName": "Dunk Low Wolf Grey Rosewood",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 140000
+  },
+  {
+    "id": 6,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1597045566677-8cf032ed6634?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "Jordan",
+    "enName": "Jordan 1 x Travis Scott Retro Low OG SP Black Phantom",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 990000
+  },
+  {
+    "id": 7,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1511405946472-a37e3b5ccd47?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "IAB",
+    "enName": "IAB Studio Pigment Sweatshirt & Mini Bag Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 139000
+  },
+  {
+    "id": 8,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1551028719-00167b16eac5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=8",
+    "brandName": "The North Face",
+    "enName": "The North Face 1996 Eco Nuptse Jacket Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 275000
+  },
+  {
+    "id": 9,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1512374382149-233c42b6a83b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=80",
+    "brandName": "Nike",
+    "enName": "Dunk Low Wolf Grey Rosewood",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 140000
+  },
+  {
+    "id": 10,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1597045566677-8cf032ed6634?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "Jordan",
+    "enName": "Jordan 1 x Travis Scott Retro Low OG SP Black Phantom",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 990000
+  },
+  {
+    "id": 11,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1511405946472-a37e3b5ccd47?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "brandName": "IAB",
+    "enName": "IAB Studio Pigment Sweatshirt & Mini Bag Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 139000
+  },
+  {
+    "id": 12,
+    "thumnailImageUrl": "https://images.unsplash.com/photo-1551028719-00167b16eac5?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=735&q=8",
+    "brandName": "The North Face",
+    "enName": "The North Face 1996 Eco Nuptse Jacket Black",
+    "krName": "덩크 로우 울프 그레이 로즈우드",
+    "price": 275000
+  }
+]

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,11 +1,92 @@
 import React from 'react';
+import MainCarousel from './MainCarousel/MainCarousel';
+import MainShortCutItem from './MainShortCutItem/MainShortCutItem';
+import MainReuse from './MainReuse/MainReuse';
+import styled from 'styled-components';
 
 const Main = () => {
   return (
-    <div>
-      <div>Main Page</div>
-    </div>
+    <MainWrapper>
+      <MainCarousel />
+      <MainBox>
+        <MainShortCutList>
+          {MAIN_SHORTCUT.map(({ id, img, categoryName }) => (
+            <MainShortCutItem key={id} img={img} title={categoryName} />
+          ))}
+        </MainShortCutList>
+        <MainReuse />
+      </MainBox>
+    </MainWrapper>
   );
 };
 
 export default Main;
+
+const MainWrapper = styled.div`
+  padding-top: 101px;
+`;
+
+const MainBox = styled.div`
+  margin-top: 35px;
+`;
+
+const MainShortCutList = styled.div`
+  width: 75%;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`;
+
+const MAIN_SHORTCUT = [
+  {
+    id: 1,
+    img: 'https://images.unsplash.com/photo-1600003014755-ba31aa59c4b6?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80',
+    categoryName: '한정판',
+  },
+  {
+    id: 2,
+    img: 'https://images.unsplash.com/photo-1490578474895-699cd4e2cf59?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1171&q=80',
+    categoryName: '남성추천',
+  },
+  {
+    id: 3,
+    img: 'https://images.unsplash.com/photo-1620739482082-17c6c0a2fe2d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=948&q=80',
+    categoryName: '여성추천',
+  },
+  {
+    id: 4,
+    img: 'https://images.unsplash.com/photo-1620739531203-7fdb5407ce32?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=818&q=80',
+    categoryName: '셀럽픽',
+  },
+  {
+    id: 5,
+    img: 'https://images.unsplash.com/photo-1591892150204-2f872745bc4b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    categoryName: '이번주 브랜드관',
+  },
+  {
+    id: 6,
+    img: 'https://images.unsplash.com/photo-1611403570720-162d8829689a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80 ',
+    categoryName: '정가 아래',
+  },
+  {
+    id: 7,
+    img: 'https://images.unsplash.com/photo-1589363460779-cd717d2ed8fa?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1332&q=80',
+    categoryName: '인기 럭셔리',
+  },
+  {
+    id: 8,
+    img: 'https://images.unsplash.com/photo-1467810563316-b5476525c0f9?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1169&q=80',
+    categoryName: '연말 선물',
+  },
+  {
+    id: 9,
+    img: 'https://images.unsplash.com/photo-1558769132-cb1aea458c5e?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    categoryName: '겨울 코디',
+  },
+  {
+    id: 10,
+    img: 'https://images.unsplash.com/photo-1611403570720-162d8829689a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    categoryName: '수수료 할인',
+  },
+];

--- a/src/pages/Main/MainCarousel/MainCarousel.js
+++ b/src/pages/Main/MainCarousel/MainCarousel.js
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+const MainCarousel = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleSlide = index => {
+    if (index < 0) {
+      index = SLIDE.length - 1;
+    } else if (index >= SLIDE.length) {
+      index = 0;
+    }
+    setCurrentIndex(index);
+  };
+
+  const onClickSlideBtn = direction => {
+    handleSlide(currentIndex + direction);
+  };
+
+  return (
+    <CarouselWrapper>
+      <CarouselPrevBtn onClick={() => onClickSlideBtn(-1)}>
+        &#12296;
+      </CarouselPrevBtn>
+      <CarouselNextBtn onClick={() => onClickSlideBtn(1)}>
+        &#12297;
+      </CarouselNextBtn>
+      <CarouselSliderList currentIndex={currentIndex}>
+        {SLIDE.map(({ id, title, subTitle, url }) => (
+          <CarouselSlideItem key={id}>
+            <CarouselTitle>{title}</CarouselTitle>
+            <CarouselSubTitle>{subTitle}</CarouselSubTitle>
+            <button>
+              <Link to="/shop">자세히 알아보기 &#12297;</Link>
+            </button>
+            <img src={url} alt={title} />
+          </CarouselSlideItem>
+        ))}
+      </CarouselSliderList>
+    </CarouselWrapper>
+  );
+};
+
+export default MainCarousel;
+
+const CarouselWrapper = styled.div`
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+`;
+
+const CarouselPrevBtn = styled.div`
+  position: absolute;
+  top: 45%;
+  left: 80px;
+  z-index: 90;
+  font-size: 40px;
+  color: rgba(255, 255, 255, 0.5);
+  border-radius: 15px;
+  cursor: pointer;
+
+  &:hover {
+    color: rgba(255, 255, 255, 1);
+    transition: all 0.5s ease-in-out;
+  }
+`;
+
+const CarouselNextBtn = styled.div`
+  position: absolute;
+  top: 45%;
+  right: 80px;
+  font-size: 40px;
+  z-index: 90;
+  color: rgba(255, 255, 255, 0.5);
+  border-radius: 15px;
+  cursor: pointer;
+
+  &:hover {
+    color: rgba(255, 255, 255, 1);
+    transition: all 0.5s ease-in-out;
+  }
+`;
+
+const CarouselSliderList = styled.div`
+  width: 300%;
+  height: 400px;
+  display: flex;
+  transform: translateX(${props => props.currentIndex * -33.3333}%);
+  transition: all 0.7s ease-in-out;
+`;
+
+const CarouselSlideItem = styled.div`
+  width: 100%;
+  height: 400px;
+  position: relative;
+  background-color: ${({ theme }) => theme.mainBrandBlack};
+
+  button {
+    all: unset;
+    font-size: 22px;
+    position: absolute;
+    bottom: 100px;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 90;
+    color: white;
+    border-bottom: ${({ theme }) => theme.globalBoardStyle};
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  img {
+    width: 100%;
+    opacity: 0.4;
+    object-position: 0px -300px;
+  }
+`;
+
+const CarouselTitle = styled.h1`
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 90;
+  font-size: 46px;
+  font-weight: Bold;
+  color: white;
+`;
+
+const CarouselSubTitle = styled.h2`
+  position: absolute;
+  top: 42%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 22px;
+  color: ${({ theme }) => theme.buttonBuy};
+  z-index: 90;
+`;
+
+const SLIDE = [
+  {
+    id: 1,
+    title: 'Artist x COLABO 협업 굿즈',
+    subTitle: '선착순 구매 기회',
+    url: 'https://images.unsplash.com/photo-1523398002811-999ca8dec234?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=705&q=80',
+  },
+  {
+    id: 2,
+    title: '12일간 매일 다른 선물',
+    subTitle: '12/23(금) ~ 1/6(금) / 매일 오전 10시 - 자정 12시',
+    url: 'https://images.unsplash.com/photo-1602067120389-6af881963470?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+  },
+  {
+    id: 3,
+    title: '판매 시 선착순 3만 포인트',
+    subTitle: '1/6(금) 00:00~ 예약 소진 시 자동 종료 ',
+    url: 'https://images.unsplash.com/photo-1594035795389-9363dd86b113?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+  },
+];

--- a/src/pages/Main/MainProduct/MainProduct.js
+++ b/src/pages/Main/MainProduct/MainProduct.js
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const MainProduct = () => {
+  const [mainProductData, setMainProductData] = useState([]);
+  const navigate = useNavigate();
+
+  const goToShop = () => {
+    navigate('/shop');
+  };
+
+  useEffect(() => {
+    fetch('/data/productData.json', {
+      method: 'GET',
+    })
+      .then(res => res.json())
+      .then(data => {
+        setMainProductData(data);
+      });
+  }, []);
+
+  return (
+    <MainProductWrapper>
+      {mainProductData.map(product => {
+        const productPrice = product.price.toLocaleString();
+        return (
+          <MainProductBox key={product.id}>
+            <MainProductThumb>
+              <img
+                src={product.thumnailImageUrl}
+                alt={product.enName}
+                onClick={goToShop}
+              />
+            </MainProductThumb>
+            <MainProductBrandTitle>{product.brandName}</MainProductBrandTitle>
+            <MainProductTitle>
+              <h3>{product.enName}</h3>
+              <h4>{product.krName}</h4>
+            </MainProductTitle>
+            <MainProductPrice>{productPrice}원</MainProductPrice>
+            <MainProductCurrentPrice>즉시 구매가</MainProductCurrentPrice>
+          </MainProductBox>
+        );
+      })}
+    </MainProductWrapper>
+  );
+};
+
+export default MainProduct;
+
+const MainProductWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin-bottom: 80px;
+`;
+
+const MainProductBox = styled.div`
+  width: 250px;
+  margin: 40px 0px;
+`;
+
+const MainProductThumb = styled.div`
+  width: 250px;
+  height: 250px;
+  border-radius: 10px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    object-position: 0px -30px;
+    cursor: pointer;
+  }
+`;
+
+const MainProductBrandTitle = styled.div`
+  margin: 10px 8px;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: bold;
+  color: ${({ theme }) => theme.mainBrandBlack};
+  border-bottom: 2px solid ${({ theme }) => theme.mainBrandBlack};
+`;
+
+const MainProductTitle = styled.p`
+  margin: 0px 8px;
+  font-size: 14px;
+  line-height: 17px;
+
+  h3 {
+    font-size: 14px;
+  }
+
+  h4 {
+    font-size: 12px;
+    color: ${({ theme }) => theme.mainBrandGray05};
+  }
+`;
+
+const MainProductPrice = styled.p`
+  margin: 12px 0px 0px 8px;
+  font-size: 16px;
+  font-weight: bold;
+`;
+
+const MainProductCurrentPrice = styled.p`
+  margin: 5px 8px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.mainBrandGray05};
+`;

--- a/src/pages/Main/MainReuse/MainReuse.js
+++ b/src/pages/Main/MainReuse/MainReuse.js
@@ -1,0 +1,160 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import MainProduct from '../MainProduct/MainProduct';
+import styled from 'styled-components';
+import { positionCenter } from '../../../styles/mixin';
+
+const MainReuse = () => {
+  const [isScroll, setIsScroll] = useState(false);
+
+  const onClickGoToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', () => {
+      const isTop = window.scrollY < 500;
+      setIsScroll(!isTop);
+    });
+  }, []);
+
+  return (
+    <MainReuseWrapper>
+      {MAIN_BANNER.map(
+        ({ id, title, subTitle, img, categoryTitle, categorySubTitle }) => {
+          return (
+            <MainReuseBox key={id}>
+              <MainBanner>
+                <MainBannerTitle>{title}</MainBannerTitle>
+                <MainBannerSubTitle>{subTitle}</MainBannerSubTitle>
+                <img src={img} alt={title} />
+                <button>
+                  <Link to="/shop">지금 거래하기 &#12297;</Link>
+                </button>
+              </MainBanner>
+              <MainProductAlignBox>
+                <MainCategoryTitle>{categoryTitle}</MainCategoryTitle>
+                <MainCategorySubTitle>{categorySubTitle}</MainCategorySubTitle>
+                <MainProduct />
+              </MainProductAlignBox>
+            </MainReuseBox>
+          );
+        }
+      )}
+      {isScroll && <AtTheTop onClick={onClickGoToTop}>&#8593;</AtTheTop>}
+    </MainReuseWrapper>
+  );
+};
+
+export default MainReuse;
+
+const MainReuseWrapper = styled.div`
+  position: relative;
+`;
+const MainReuseBox = styled.div``;
+
+const MainBanner = styled.div`
+  width: 100%;
+  height: 400px;
+  margin-top: 45px;
+  position: relative;
+  background-color: ${({ theme }) => theme.mainBrandBlack};
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    object-position: 0px -1300px;
+    opacity: 0.6;
+    filter: blur(4px);
+  }
+
+  button {
+    all: unset;
+    position: absolute;
+    bottom: 100px;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 20px;
+    border-bottom: ${({ theme }) => theme.globalBoardStyle};
+    color: white;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+`;
+
+const MainBannerTitle = styled.h1`
+  ${positionCenter('absolute')}
+  top: 30%;
+  z-index: 999;
+  font-size: 50px;
+  font-weight: bold;
+  color: white;
+`;
+
+const MainBannerSubTitle = styled.h2`
+  ${positionCenter('absolute')}
+  top: 42%;
+  z-index: 999;
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.7);
+`;
+
+const MainProductAlignBox = styled.div`
+  width: 75%;
+  margin: 0 auto;
+`;
+
+const MainCategoryTitle = styled.h3`
+  margin-top: 50px;
+  color: ${({ theme }) => theme.mainBrandBlack};
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+const MainCategorySubTitle = styled.h4`
+  margin: 5px 0px;
+  color: ${({ theme }) => theme.mainBrandGray05};
+  font-size: 14px;
+`;
+
+const AtTheTop = styled.div`
+  width: 45px;
+  height: 45px;
+  position: absolute;
+  right: 80px;
+  bottom: 0px;
+  font-size: 20px;
+  text-align: center;
+  line-height: 40px;
+  border: 1px solid ${({ theme }) => theme.mainBrandBlack};
+  border-radius: 50%;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.mainBrandBlack};
+    color: white;
+  }
+`;
+
+const MAIN_BANNER = [
+  {
+    id: 1,
+    title: 'The Best of 2022',
+    subTitle: '올해 ICECREAM을 빛낸 아이템',
+    img: 'https://images.unsplash.com/photo-1590371447356-10bdb441b91d?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=626&q=80',
+    categoryTitle: 'Most Popular',
+    categorySubTitle: '인기 상품',
+  },
+  {
+    id: 2,
+    title: 'Under Retail',
+    subTitle: '정가보다 저렴한 시세',
+    img: 'https://images.unsplash.com/photo-1574427797991-b086946fa9e7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80',
+    categoryTitle: 'New In',
+    categorySubTitle: '신규 등록 상품',
+  },
+];

--- a/src/pages/Main/MainShortCutItem/MainShortCutItem.js
+++ b/src/pages/Main/MainShortCutItem/MainShortCutItem.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const MainShortCutItem = ({ img, title }) => {
+  return (
+    <MainShortCutItemWrapper>
+      <MainShortCutItemBox>
+        <img src={img} alt={title} />
+      </MainShortCutItemBox>
+      <MainShortCutItemTitle>{title}</MainShortCutItemTitle>
+    </MainShortCutItemWrapper>
+  );
+};
+
+export default MainShortCutItem;
+
+const MainShortCutItemWrapper = styled.div`
+  text-align: center;
+`;
+
+const MainShortCutItemBox = styled.div`
+  margin-top: 15px;
+  width: 200px;
+  height: 100px;
+  background-color: ${({ theme }) => theme.mainBrandBlack};
+  border-radius: 10px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    object-position: 0px -10px;
+    cursor: pointer;
+  }
+`;
+
+const MainShortCutItemTitle = styled.p`
+  margin-top: 8px;
+  color: #333;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 메인페이지 레이아웃 구현
- 메인페이지 캐러셀 구현 완료

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 메인페이지 레이아웃 구현
- 이미지 없이 박스모델링으로 진행
- 이미지 추가 

2. 메인페이지 캐러셀 구현 완료
- 버튼을 통한 prevSlide, nextSlide 이동 구현
- 마지막 인덱스 이후 첫 인덱스로 돌아와 다시 반복 슬라이드까지 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- styled-components를 통해 props를 전달하는 과정을 이해할 수 있었습니다.
- styled-components 역시 작업이 진행될수록 코드가 길어지는 단점이 있지만, 그래도 컴포넌트별로 독립적으로 스타일을 사용할 수 있다는 점이 큰 장점이었던 것 같습니다.
- styled-components를 더 효율적으로 사용할 수 있는 방법이 있는지 궁금합니다.

<br />

## :: 기타 질문 및 특이 사항
- 시간상 무한 슬라이드는 추가기능으로 구현해봐야 할 것 같습니다.
